### PR TITLE
Add handling of progress check event type

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,22 +35,26 @@ The file should be in tab separated values (tsv) format.
 The first line is ignored and may include headers.
 Each following line should have a single event, in this format:
 
-- The fist entry is ignored
+- The first entry is ignored
 - The second entry is the name of the event.
 - The third entry is a semicolon separated list of topics taught in the event.
 - The fourth entry is a semicolon separated list of topics required by the event.
 
-Each event has a type of either <i>lecture</i>, <i>lab</i>, <i>homework</i>, or <i>project</i>.
+Each event has a type of either <i>lecture</i>, <i>lab</i>, <i>homework</i>, <i>project</i>, or <i>progress check</i>.
 Each event also has a unit number and group id.
 No two events should have the same type, unit, and group.
 This information is parsed from the event name, in this manner:
 
 - If the name includes a hyphen, only the part of the name preceding any hyphens is considered.
-- The event type is determined by the presence of 'lecture', 'lab', 'homework' (or 'hw'), or 'project' in the event
-  name, ignoring casing.
+- The event type is determined by the presence of the type in the event name, ignoring casing.
+  - 'lecture' for <i>lecture</i>
+  - 'lab' for <i>lab</i>
+  - 'homework' or 'hw' for <i>homework</i>
+  - 'project' for <i>project</i>
+  - 'progress' or 'check' for <i>progress check</i>
 - The unit number is parsed from the first uninterrupted series of digits in the name.
 - The group id is the character immediately following the last character of the unit number, if not whitespace.
-  A <i>project</i> may omit the group id, if it is the only <i>project</i> in the unit.
+  - An event may omit this group id if it is the only event of its type without a group id in its unit.
 
 Chronological ordering of events is based on the unit number, then group id, then event type.
 Event type orderings from first to last are:
@@ -59,6 +63,7 @@ Event type orderings from first to last are:
 2. <i>Lab</i>
 3. <i>Homework</i>
 4. <i>Project</i>
+5. <i>Progress Check</i>
 
 Example events table (also found in demo_events.tsv):
 
@@ -74,6 +79,7 @@ Example events table (also found in demo_events.tsv):
 |                                                     |     Lab 1c - Subtraction     |                |           Subtraction |
 |                                                     |  Homework 1c - Subtraction   |                |           Subtraction |
 |                                                     | Project 1 - Basic Operations |                | Addition; Subtraction |
+|                                                     |       Progress Check 1       |                | Addition; Subtraction |
 |                                                     | Lecture 2a - Multiplication  | Multiplication |                       |
 |                                                     |   Lab 2a - Multiplication    |                |        Multiplication |
 |                                                     | Homework 2a - Multiplication |                |        Multiplication |

--- a/curriculum_flow_charts.py
+++ b/curriculum_flow_charts.py
@@ -51,10 +51,12 @@ if __name__ == '__main__':
                         extra information or be left empty. The second column specifies the name of the event. The 
                         name should include an event type (lecture, lab, homework (hw), or project) and an event id 
                         starting with the unit number, followed by a letter (e.g. '1a', '4c'). Events are 
-                        chronologically ordered by unit, then the alphabetical part of their id (Example event name: 
-                        'Lecture 3b - Learning stuff'). Projects may have the alphabetical part of their id omitted, 
-                        and there may only be one project in each unit. Extra parts of the event name should come 
-                        after a hyphen. The third column is a semicolon seperated list of topics taught in the event. 
+                        chronologically ordered by unit, then the alphabetical part of their id
+                        (Example event name: 'Lecture 3b - Learning stuff').
+                        Events may have the alphabetical part of their id omitted,
+                        if they are the only event without an id of their type within their unit.
+                        Extra parts of the event name should come after a hyphen. 
+                        The third column is a semicolon seperated list of topics taught in the event. 
                         The fourth column is a semicolon seperated list of topics required for the event.''')
     parser.add_argument('--output-dir', default='output', help='''Specifies a directory to save output files to.
                         Defaults to \'./output/\'.''')

--- a/util/dependency_info.py
+++ b/util/dependency_info.py
@@ -61,7 +61,7 @@ class DependencyInfo:
 
     def finalize(self, info_level: InfoLevel):
         """
-        Ensures there is only independent event of each type for each unit.
+        Ensures there is only one independent event of each type for each unit.
         For each event, removes required topics that are dependencies of other required topics for that event.
         For each topic, removes dependencies that are dependencies of other dependencies for that topic.
         Prints information regarding removals to the console.

--- a/util/event.py
+++ b/util/event.py
@@ -9,6 +9,7 @@ class EventType(Enum):
     LAB = 2
     HOMEWORK = 3
     PROJECT = 4
+    PROGRESS_CHECK = 5
 
     def __lt__(self, other):
         return self.value < other.value
@@ -134,6 +135,10 @@ def __parse_event_type(name: str) -> EventType:
         if event_type is not None:
             raise ValueError(f'Cannot distinguish event type of \'{name}\'')
         event_type = EventType.PROJECT
+    if 'progress' in name or 'check' in name:
+        if event_type is not None:
+            raise ValueError(f'Cannot distinguish event type of \'{name}\'')
+        event_type = EventType.PROGRESS_CHECK
     if event_type is None:
         raise ValueError(f'Cannot distinguish event type of \'{name}\'')
     return event_type
@@ -173,6 +178,4 @@ def _parse_type_unit_and_group(event_name: str) -> tuple[EventType, int, str | N
         unit_number, group_id = __parse_unit_and_group(short_name)
     except ValueError as e:
         raise ValueError(f'Error while parsing unit number and group id of \'{event_name}\': {e}')
-    if group_id is None and event_type != EventType.PROJECT:
-        raise ValueError(f'Event \'{event_name}\' is missing an id')
     return event_type, unit_number, group_id


### PR DESCRIPTION
Adds progress check as a valid event type.

Also allowed any event type to be independent of a group as long as it is the only event of that type that is independent of a group within its unit. Previously only a project could do this. Now any event can.